### PR TITLE
feat: cleanup login example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,14 @@ to help developers get their hands on a fully functional and easy to understand 
 
 The tutorial can be found [here](https://docs.login.xyz).
 
-## Running the Example
+## Getting Started
 
-Add the following to `.env.local.example` in order to run the application:
+Make a copy of `.env.local.example` to `.env.local`, and fill in the following two values. For example:
 
 ```
+NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=somereallysecretsecret
-JWT_SECRET=itshouldbealsoverysecret
-DOMAIN=localhost:3000
 ```
-
-Once updated, rename the file to `.env`. 
 
 You can then use the following commands to run the example:
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -16,9 +16,7 @@ export default function Header() {
       </noscript>
       <div className={styles.signedInStatus}>
         <p
-          className={`nojs-show ${
-            !session && loading ? styles.loading : styles.loaded
-          }`}
+          className={`nojs-show ${!session && loading ? styles.loading : styles.loaded}`}
         >
           {!session && (
             <>

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -24,8 +24,8 @@ export default async function auth(req, res) {
       async authorize(credentials) {
         try {
           const siwe = new SiweMessage(JSON.parse(credentials?.message || "{}"))
-          const domain = process.env.DOMAIN
-          if (siwe.domain !== domain) {
+          const nextAuthUrl = new URL(process.env.NEXTAUTH_URL)
+          if (siwe.domain !== nextAuthUrl.host) {
             return null
           }
 
@@ -58,14 +58,12 @@ export default async function auth(req, res) {
     session: {
       strategy: "jwt",
     },
-    jwt: {
-      secret: process.env.JWT_SECRET,
-    },
-    secret: process.env.NEXT_AUTH_SECRET,
+    secret: process.env.NEXTAUTH_SECRET,
     callbacks: {
       async session({ session, token }) {
         session.address = token.sub
         session.user.name = token.sub
+        session.user.image = 'https://www.fillmurray.com/128/128'
         return session
       },
     },

--- a/pages/styles.css
+++ b/pages/styles.css
@@ -30,3 +30,24 @@ iframe {
   border-radius: 0.5rem;
   filter: invert(1);
 }
+
+button {
+  margin: 0 0 0.75rem 0;
+  text-decoration: none;
+  padding: 0.7rem 1.4rem;
+  border: 1px solid #346df1;
+  background-color: #346df1;
+  color: #fff;
+  font-size: 1rem;
+  border-radius: 4px;
+  transition: all 0.1s ease-in-out;
+  font-weight: 500;
+  position: relative;
+
+}
+
+button:hover {
+  cursor: pointer;
+  box-shadow: inset 0 0 5rem rgb(0 0 0 / 20%);
+}
+


### PR DESCRIPTION
ndom91 from NextAuth.js here!

First of all, thanks a lot for the example project and tutorial write-up!

When checking out the example, I ended up making a few changes and figured I'd open up a PR to upstream them if you're interested.

First, I cleaned up the environment variables. No longer is an explicit `DOMAIN` env var necessary. We can just grab the `host` off the already required `NEXTAUTH_URL`. Also `JWT_SECRET` isn't required explicitly any longer.

Also, I styled the 'Sign-in' button a bit and added a dummy 'fillmurray' user profile pic image just for fun.

For example:

![image](https://user-images.githubusercontent.com/7415984/161629843-083e407f-20d0-4011-a186-b1af5140a1c1.png)
