### PR TITLE
Fix bug to make it works with wagmi 0.2.x

### DIFF
--- a/pages/siwe.tsx
+++ b/pages/siwe.tsx
@@ -14,11 +14,11 @@ function Siwe() {
       const callbackUrl = '/protected';
       const message = new SiweMessage({
         domain: window.location.host,
-        address: res.account,
+        address: res.data?.account,
         statement: 'Sign in with Ethereum to the app.',
         uri: window.location.origin,
         version: '1',
-        chainId: res.chain?.id,
+        chainId: res.data?.chain?.id,
         nonce: await getCsrfToken()
       });
       const {data: signature, error} = await signMessage({ message: message.prepareMessage() });


### PR DESCRIPTION
In my last PR, I updated the `connect` function for `connectAsync` this works well, but I didn't see that you were running an older version of wagmi (0.2.28). Since the 0.3.x version has breaking changes (https://wagmi.sh/docs/migrating-to-03), I didn't update wagmi and complied to this version.

I run the code in local, everything works well this time. Sorry for last PR