### PR TITLE
Add VERCEL_URL domain fallback to support preview deployments

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -24,8 +24,18 @@ export default async function auth(req, res) {
       async authorize(credentials) {
         try {
           const siwe = new SiweMessage(JSON.parse(credentials?.message || "{}"))
-          const nextAuthUrl = new URL(process.env.NEXTAUTH_URL)
-          if (siwe.domain !== nextAuthUrl.host) {
+
+          const nextAuthUrl =
+            process.env.NEXTAUTH_URL ||
+            (process.env.VERCEL_URL
+              ? `https://${process.env.VERCEL_URL}`
+              : null)
+          if (!nextAuthUrl) {
+            return null
+          }
+
+          const nextAuthHost = new URL(nextAuthUrl).host
+          if (siwe.domain !== nextAuthHost) {
             return null
           }
 


### PR DESCRIPTION
I ran into some trouble following this example when deploying to Vercel and using preview deployments. The NextAuth docs say that the `NEXTAUTH_URL` environment variable is unnecessary on Vercel, but I initially missed that this environment variable was being referenced in this part of the code.

To fix it, I added a fallback that references `VERCEL_URL` if `NEXTAUTH_URL` is missing, prepending the URL with `https://` since it's not a valid argument for the `URL` constructor.