### PR TITLE
Removed <a> tag inside <Link>

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -18,7 +18,7 @@ export default function Footer() {
         </li>
         <li className={styles.navItem}>
           <Link href="/policy">
-            <a>Policy</a>
+            Policy
           </Link>
         </li>
         <li className={styles.navItem}>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -59,12 +59,12 @@ export default function Header() {
         <ul className={styles.navItems}>
           <li className={styles.navItem}>
             <Link href="/">
-              <a>Home</a>
+              Home
             </Link>
           </li>
           <li className={styles.navItem}>
             <Link href="/siwe">
-              <a>SIWE</a>
+              SIWE
             </Link>
           </li>
         </ul>


### PR DESCRIPTION
Removes <a> tags inside <Link> tags.

More details: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor