### PR TITLE
fix: csrf request headers

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -29,7 +29,7 @@ export default async function auth(req: any, res: any) {
           const result = await siwe.verify({
             signature: credentials?.signature || "",
             domain: nextAuthUrl.host,
-            nonce: await getCsrfToken({ req }),
+            nonce: await getCsrfToken({ req: { headers: req.headers }}),
           })
 
           if (result.success) {


### PR DESCRIPTION
Resolves the error thrown during authorization:

```bash
https://next-auth.js.org/errors#client_fetch_error Unexpected token E in JSON at position 0 {
  error: {
    message: 'Unexpected token E in JSON at position 0',
    stack: 'SyntaxError: Unexpected token E in JSON at position 0\n' +
      '    at JSON.parse (<anonymous>)\n' +
      '    at parseJSONFromBytes (node:internal/deps/undici/undici:6662:19)\n' +
      '    at successSteps (node:internal/deps/undici/undici:6636:27)\n' +
      '    at node:internal/deps/undici/undici:1236:60\n' +
      '    at node:internal/process/task_queues:140:7\n' +
      '    at AsyncResource.runInAsyncScope (node:async_hooks:203:9)\n' +
      '    at AsyncResource.runMicrotask (node:internal/process/task_queues:137:8)\n' +
      '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)',
    name: 'SyntaxError'
  },
  url: 'http://localhost:3000/api/auth/csrf',
  message: 'Unexpected token E in JSON at position 0'
}
```