### PR TITLE
Update [...nextauth].ts

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -34,7 +34,7 @@ export default async function auth(req: any, res: any) {
 
           if (result.success) {
             return {
-              id: siwe.address,
+              id: result.data.address,
             }
           }
           return null


### PR DESCRIPTION
Better to maybe return address from verify result instead of the SIWE message.

This will not make a huge difference since we are checking `result.success == true` before returning the address, but curious if my proposal makes sense or if this was intentional to return `siwe.address` because in my app i am returning `result.data.address`